### PR TITLE
Update Preferences -> Settings for MacOS

### DIFF
--- a/tutorials/checkstyle.md
+++ b/tutorials/checkstyle.md
@@ -71,13 +71,15 @@ For example, you can run `gradlew checkstyleMain checkstyleTest` to verify that 
 Given below are the steps to install the Checkstyle-IDEA plugin so that Intellij can alert you about code style problems as you write code.
 
 1. Install the Checkstyle-IDEA plugin as follows:
-   1. `File` \> `Settings` (Windows/Linux), or `IntelliJ IDEA` \> `Preferences…​` (macOS)
+   1. `File` \> `Settings` (Windows/Linux), or `IntelliJ IDEA` \> `Settings…​` (macOS)
    1. Select `Plugins` (on the left slide menu in the dialog that pops up)
    1. Select `Marketplace` (on to top center of the same dialog box)
    1. Find the plugin.
    1. Restart the IDE to complete the installation.
 
-1. Click `File` \> `Settings…​` \> `Tools` \> `Checkstyle`
+1. Click `File` \> `Settings` (Windows/Linux), or `IntelliJ IDEA` \> `Settings…​` (macOS)
+
+1. Click `Tools` \> `Checkstyle`
 
 1. Set `Scan Scope` to `Only Java sources (including tests)`, so that the plugin will run checkstyle for our test source codes as well
 

--- a/tutorials/intellijCodeStyle.md
+++ b/tutorials/intellijCodeStyle.md
@@ -11,7 +11,7 @@ IntelliJ’s default style is mostly compliant with [ours](../conventions/java/)
 
 ## Tweak: `switch-case` style {{ icon_level_basic }}
 
-1. Go to `File` → `Settings…​` (Windows/Linux), or `IntelliJ IDEA` → `Preferences…​` (macOS).
+1. Go to `File` → `Settings…​` (Windows/Linux), or `IntelliJ IDEA` → `Settings…​` (macOS).
 1. Click on `Editor` → `Code style`→ `Java` (see the screenshot below).<br>
    ![](images/intellij/codeStyle-switch.png)
 1. Click on the `Wrapping and Braces` tab and un-tick the `Indent 'case' branches` option (as shown in the screenshot above).
@@ -19,7 +19,7 @@ IntelliJ’s default style is mostly compliant with [ours](../conventions/java/)
 
 ## Tweak: `import` order {{ icon_level_intermediate }}
 
-1. Go to `File` → `Settings…​` (Windows/Linux), or `IntelliJ IDEA` → `Preferences…​` (macOS).
+1. Go to `File` → `Settings…​` (Windows/Linux), or `IntelliJ IDEA` → `Settings…​` (macOS).
 1. Select `Editor` → `Code Style` → `Java`.
 1. Click on the `Imports` tab to set the import order.
    * For `Class count to use import with '*'` and `Names count to use static import with '*'`: Set to `999` to prevent IntelliJ from contracting the import statements.


### PR DESCRIPTION
Fixes #14 

Updated references of `Preferences` to `Settings` in the guides as MacOS changed for Ventura onwards.