### PR TITLE
[#26] Add padding for `img` component

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -190,6 +190,10 @@ h2 {
     border-top: 5px solid #0073e6;
 }
 
+img {
+    margin: 20px;
+}
+
 .indented-less {
     padding-left: 10px;
 }


### PR DESCRIPTION
Fixes #26

## Description:
Modified `main.css` to give `img` components a padding of `20px` for improved readability as mentioned in #26.


### Screenshots:

#### Before:
<img width="728" alt="Screenshot 2024-07-20 at 4 17 35 PM" src="https://github.com/user-attachments/assets/aa82c7e8-58c7-48df-bcfc-3d096256e66c">

#### After:
<img width="669" alt="Screenshot 2024-07-20 at 4 17 39 PM" src="https://github.com/user-attachments/assets/15476478-07e6-4af0-9213-92f175300564">
