### PR TITLE
[#50] Add Resources section to Java installation guide

### DIFF
--- a/tutorials/javaInstallationMac.md
+++ b/tutorials/javaInstallationMac.md
@@ -69,6 +69,14 @@ If you have multiple versions of Java installed, you can switch between them usi
   sdk default java <version>
   ```
 
+<!-- ======================================================================= -->
+
+## Resources
+
+* [SDKMAN Documentation](https://sdkman.io/)
+
+* [SDKMAN Video Installation Guide](https://www.youtube.com/watch?v=5cc8IZRvRcI&t=32s)
+
 --------------------------------------------------------------------------------
 
 **Authors:**

--- a/tutorials/javaInstallationMac.md
+++ b/tutorials/javaInstallationMac.md
@@ -74,7 +74,6 @@ If you have multiple versions of Java installed, you can switch between them usi
 ## Resources
 
 * [SDKMAN Documentation](https://sdkman.io/)
-
 * [SDKMAN Video Installation Guide](https://www.youtube.com/watch?v=5cc8IZRvRcI&t=32s)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Part of #50

Added links to the official SDKMAN documentation and a video installation guide, might be useful for students who want to delve deeper into the software or need a more visual approach to guide them through the process of installing the tool.