### PR TITLE
[#81] Fix broken image link in AddRemark AB3 tutorial

### DIFF
--- a/tutorials/ab3AddRemark.md
+++ b/tutorials/ab3AddRemark.md
@@ -269,7 +269,7 @@ Then insert the following into [`main/resources/view/PersonListCard.fxml`](https
 
 That’s it! Fire up the application again and you should see something like this:
 
-![$remark shows up in each entry](../images/add-remark/$Remark.png)
+![$remark shows up in each entry](images/add-remark/\$Remark.png)
 
 ## Modify `Person` to support a `Remark` field
 


### PR DESCRIPTION
Fixes #81 

<img width="828" alt="image" src="https://github.com/user-attachments/assets/887ab62e-dda3-4a69-bc8f-f08824f7d3bb">

I went with the first proposed solution of escaping the `$` symbol. However some auto formatters _might_ remove this escape character (tested on VSC and it did but IntelliJ did not).
