### PR TITLE
[AB3: Removing Fields] Add git diff for removing address field

### DIFF
--- a/tutorials/ab3RemovingFields.md
+++ b/tutorials/ab3RemovingFields.md
@@ -113,6 +113,8 @@ In `src/test/data/`, data meant for testing purposes are stored. While keeping t
 
 You can go through each individual `json` file and manually remove the `address` field.
 
+Once you've finished, you can cross-check your changes with this [diff](https://github.com/mfjkri/addressbook-level3/commit/3e658057198ca9e1ff0fce2ce1b353df78e0be86).
+
 [:fas-arrow-left: Previous](ab3AddRemark.md) | [:fas-arrow-up: **ToC**](ab3.md)
 
 --------------------------------------------------------------------------------

--- a/tutorials/ab3RemovingFields.md
+++ b/tutorials/ab3RemovingFields.md
@@ -113,7 +113,7 @@ In `src/test/data/`, data meant for testing purposes are stored. While keeping t
 
 You can go through each individual `json` file and manually remove the `address` field.
 
-Once you've finished, you can cross-check your changes with this [diff](https://github.com/mfjkri/addressbook-level3/commit/3e658057198ca9e1ff0fce2ce1b353df78e0be86).
+After you've manually removed the address field from each relevant JSON file, you can cross-check your changes with this [diff](https://github.com/mfjkri/addressbook-level3/commit/3e658057198ca9e1ff0fce2ce1b353df78e0be86). This link provides a complete overview of all changes made throughout the guide, including the removal of the address field from various parts of AB3.
 
 [:fas-arrow-left: Previous](ab3AddRemark.md) | [:fas-arrow-up: **ToC**](ab3.md)
 


### PR DESCRIPTION
Fixes #84 
I've added a git diff to compare the changes made when removing the address field. 

Currently, the commit is on a branch in my fork of the AB3 repository, as I don't have permission to create a new remote branch on the main repository. It can cherry-picked over later after a branch is created for it and I will update the commit link again after.

Commit link: https://github.com/mfjkri/addressbook-level3/commit/3e658057198ca9e1ff0fce2ce1b353df78e0be86