### PR TITLE
[VSCode] Fix broken JUnit link

### DIFF
--- a/tutorials/vscode.md
+++ b/tutorials/vscode.md
@@ -26,6 +26,6 @@ This guide is for those who prefer to use [Visual Studio Code](https://code.visu
 * [Importing a Gradle project]({{ baseUrl }}/tutorials/vscImportingGradleProject.md)
 * [Setting up Checkstyle]({{ baseUrl }}/tutorials/vscSettingUpCheckstyle.md)
 * [Using the Debugger]({{ baseUrl }}/tutorials/vscDebugger.md)
-* [Using Junit](tutorials/vscJUnitTesting.md)
+* [Using Junit]({{ baseUrl }}/tutorials/vscJUnitTesting.md)
 * AI Tool Integrations: [GitHub Copilot]({{ baseUrl }}/tutorials/vscCopilot.md) | [Windsurf]({{ baseUrl }}/tutorials/vscWindsurf.md)
 </div>


### PR DESCRIPTION
Currently, the JUnit link at the bottom of the VSCode tutorial is broken (leads to a 404 page)
<img width="506" height="245" alt="image" src="https://github.com/user-attachments/assets/c812dea9-b238-416f-a3a1-be4d5a828bb6" />

<img width="536" height="398" alt="image" src="https://github.com/user-attachments/assets/9def3be6-2bc8-4e7f-8f4b-d2538c65d897" />
