### PR TITLE
[VSC: Windsurf] Fix broken image link

### DIFF
--- a/tutorials/vscWindsurf.md
+++ b/tutorials/vscWindsurf.md
@@ -61,7 +61,7 @@ Windsurf is an AI assistant that integrates smoothly with Visual Studio Code and
     <pic src="images/vscWindsurf/windsurfCommands.png" width="500" />
   * Refactor command
     * Click `Windsurf: Refactor` to open a menu with refactoring options.<br>
-    <pic src="images/vscWindsurf/windsurfrefactor.png" width="500" />
+    <pic src="images/vscWindsurf/windsurfRefactor.png" width="500" />
     * Choose a command, then click `Accept` ({{ icon_windows }}/{{ icon_linux}}/{{ icon_apple }} `Alt+A`) or `Reject` ({{ icon_windows }}/{{ icon_linux}}/{{ icon_apple }} `Alt+R`) to confirm or dismiss the generated code.
   * Explain command
     * Click the `Explain` button above a code block to have Windsurf explain it.


### PR DESCRIPTION
One of the image link was broken.
<img width="854" height="505" alt="image" src="https://github.com/user-attachments/assets/36000942-ad78-44ff-a44b-52fc8b8d8be9" />

Fix:
<img width="852" height="692" alt="image" src="https://github.com/user-attachments/assets/a7fb8477-a77a-4e66-aded-f6f71e457e1f" />