### PR TITLE
[VS Code] Add reminder to remove breakpoint

### DIFF
--- a/tutorials/vscDebugger.md
+++ b/tutorials/vscDebugger.md
@@ -44,7 +44,7 @@ This tutorial covers the basics of using VS Code’s debugger for Java features.
 <p/>
 
 <box type="tip" seamless>
-To remove the breakpoint, click the red dot again.
+To remove the breakpoint, click the red dot again. Remember to remove breakpoints after you are done debugging that section, so they do not interfere when debugging other parts of the code later.
 </box>
 
 * The Debugger for Java supports various breakpoints, including line breakpoints, conditional breakpoints, data breakpoints, and logpoints.


### PR DESCRIPTION
**Context:**
In the Debugger tutorial, students may forget to remove breakpoints after they’re done debugging, which can unintentionally pause future debugging sessions.

**Change:**
Added a reminder to remove breakpoints after use.

**Screenshot of change:**
Before:
<img width="355" height="41" alt="image" src="https://github.com/user-attachments/assets/a61f1309-0c8d-484a-897c-e8756b3fb675" />

After:
<img width="698" height="71" alt="image" src="https://github.com/user-attachments/assets/93219fe5-5eed-4aaf-8259-aabb2f1c0e9c" />
