### PR TITLE
docs(cursor): add tutorials for Cursor (Signup, IntelliJ, VS Code)

### DIFF
--- a/tutorials/cursorIntellij.md
+++ b/tutorials/cursorIntellij.md
@@ -1,0 +1,70 @@
+{% set title="IntelliJ IDEA - Using Cursor" %}
+<frontmatter>
+  title: "{{ title }}"
+  pageNav: 2
+</frontmatter>
+
+<include src="../common/common-fragments.md#wip-warning" />
+
+# {{ title }}
+
+Cursor is primarily built on VS Code, but it can also be used to **assist with coding tasks in IntelliJ IDEA** through the Cursor Chat web interface and integration via code snippets.  
+Think of it as having *ChatGPT connected to your IntelliJ workflow* — you can generate code, get explanations, and copy results back into your project.  
+
+---
+
+## Pre-requisites
+
+* Install [IntelliJ IDEA](https://www.jetbrains.com/idea/download/).  
+* Install the Java 17 SDK (Temurin or Oracle JDK).  
+* Sign up and log in to Cursor (see [Signing Up for Cursor](cursorSignup.md)).  
+
+---
+
+## Using Cursor with IntelliJ
+
+### Step 1: Open Cursor Chat in Browser or App
+* Open the Cursor desktop app or visit [cursor.com](https://cursor.com).  
+* Navigate to the **Chat panel**.  
+* Ask questions such as:  
+  > "Generate JUnit tests for the `Person` class"  
+  > "Explain this method in plain English"  
+
+Cursor will return results that you can copy into IntelliJ.  
+
+<pic src="images/cursor/chat.png" width="500" />
+
+---
+
+### Step 2: Paste and Adapt in IntelliJ
+* Copy generated snippets from Cursor.  
+* Paste into IntelliJ editor windows.  
+* Use IntelliJ’s **code inspections** to verify and adapt suggestions.  
+
+<box type="tip" seamless>
+Always run `./gradlew check` after pasting new code to ensure compatibility with Checkstyle and project rules.
+</box>
+
+---
+
+### Step 3: Refactor or Explain with Cursor
+* Select a block of code in IntelliJ.  
+* Copy-paste into Cursor chat.  
+* Ask Cursor to **refactor** (e.g., “make this more efficient”) or **explain** (e.g., “what does this method do?”).  
+* Cursor will provide updated code or natural-language explanations.  
+
+---
+
+## Responsible Usage
+
+* Use Cursor in IntelliJ mainly for **learning and scaffolding** (e.g., test generation, clarifying errors).  
+* Avoid using Cursor to auto-generate entire project features.  
+* Always cross-check AI output against IntelliJ inspections, unit tests, and Checkstyle rules.  
+
+<box type="info" seamless>
+Cursor complements IntelliJ’s powerful IDE features by acting as an *AI coding buddy*.  
+</box>
+
+---
+
+**Contributors**: Arshin Sikka ([@arshinsikka](https://github.com/arshinsikka))  

--- a/tutorials/cursorSignup.md
+++ b/tutorials/cursorSignup.md
@@ -1,0 +1,45 @@
+{% set title="Signing Up for Cursor" %}
+<frontmatter>
+  title: "{{ title }}"
+  pageNav: 2
+</frontmatter>
+
+<include src="../common/common-fragments.md#wip-warning" />
+
+# {{ title }}
+
+<div id="body">
+
+**Cursor is an AI-powered code editor built on top of VS Code.**  
+To use Cursor’s AI features, you need to create an account and sign in.  
+Follow the steps below to get started:
+
+## Step 1: Create a Cursor Account
+
+* Go to the [Cursor signup page](https://cursor.com).  
+* Click on **Download** for your platform (macOS, Windows, or Linux).  
+* Install Cursor just like you would install VS Code.  
+* Open Cursor after installation — you will be prompted to log in.  
+
+## Step 2: Log in to Cursor
+
+* Choose a login method:  
+  * Sign in with **Google**, **GitHub**, or **Email**.  
+  * Approve any verification prompts (email verification if required).  
+* Once signed in, Cursor unlocks AI-powered features such as chat, inline suggestions, and refactoring tools.  
+
+<pic src="images/cursor/login.png" width="400" />
+
+## Free Plan and Student Benefits
+
+* **Free Plan**: Available indefinitely, but with a **monthly token/request limit**.  
+* **Pro Student Offer**: Verified students can apply for **1 year of free Cursor Pro** (availability depends on country).  
+  <box type="warning" seamless>
+  Note: Singapore students may not have access to the Pro student plan. After the one-year period, Pro becomes paid.
+  </box>
+
+---
+
+**Contributors**: Arshin Sikka ([@arshinsikka](https://github.com/arshinsikka))  
+
+</div>

--- a/tutorials/cursorVscode.md
+++ b/tutorials/cursorVscode.md
@@ -1,0 +1,103 @@
+{% set title="VS Code - Using Cursor" %}
+<frontmatter>
+  title: "{{ title }}"
+  pageNav: 2
+</frontmatter>
+
+<include src="../common/common-fragments.md#wip-warning" />
+
+# {{ title }}
+
+Cursor is an AI-powered editor based on **Visual Studio Code**.  
+If you already know VS Code, Cursor will feel almost identical — but with AI built directly into your coding workflow.  
+Think of it as *ChatGPT inside VS Code*, helping you autocomplete, refactor, and chat about your code.  
+
+---
+
+## Pre-requisites
+
+* Download and install Cursor from [cursor.com](https://cursor.com).  
+* Sign in using Google, GitHub, or Email (see [Signing Up for Cursor](cursorSignup.md)).  
+* Ensure you have Java 17 SDK installed for CS2103/SE-EDU projects.  
+
+---
+
+## Setting Up Cursor in VS Code
+
+* Open Cursor after installation.  
+* Sign in to your Cursor account if prompted.  
+* The interface will look almost identical to VS Code, but with extra **Cursor AI icons** in the sidebar and editor toolbar.  
+
+<pic src="images/vscCursor/login.png" width="400" />
+
+---
+
+## Basic Code Completion
+
+Cursor suggests code **inline** as you type.  
+
+* In a Java file, type a comment like:  
+  ```java
+  // write a method that prints Hello World
+Cursor will display a suggestion inline.  
+* Press `Tab` to accept, or `Esc` to dismiss.  
+
+<box type="tip" seamless>
+The clearer your comment or method name, the better Cursor’s suggestion will be.
+</box>
+
+---
+
+## Cursor Chat
+
+Cursor comes with a **Chat panel**, similar to ChatGPT but aware of your codebase.  
+
+* Click on the **Cursor icon** in the sidebar.  
+* Ask a coding question, e.g.:  
+  > "Generate JUnit tests for the `Person` class"  
+  > "Explain what this `parseCommand` method does"  
+* Cursor will return explanations or code snippets you can copy directly.  
+
+<box type="warning" seamless>
+The free plan has a limited monthly quota of AI requests. Heavy usage requires a Pro plan.
+</box>
+
+---
+
+## Inline Chat (Inside the Editor)
+
+You can ask Cursor for help **directly in your code editor**.  
+
+* Highlight or place the cursor where you want help.  
+* Use the shortcut: {{ icon_windows }}/{{ icon_linux }} `Ctrl+I` | {{ icon_apple }} `Cmd+I`.  
+* Type a request such as:  
+  > "Add logging here"  
+  > "Refactor this into a helper method"  
+* Cursor’s generated code will appear inline — you can accept or reject it.  
+
+---
+
+## Refactoring and Explaining Code
+
+Cursor also supports **refactor** and **explain** commands:  
+
+* Right-click on a code block, select **Cursor: Refactor** or **Cursor: Explain**.  
+* Refactor: suggests a cleaner or more efficient version of the code.  
+* Explain: generates a natural-language explanation in the chat panel.  
+
+---
+
+## Responsible Usage
+
+Cursor is powerful, but keep in mind:  
+* Use it for **boilerplate, testing, and learning** — not for writing entire assignment features.  
+* Always verify suggestions with unit tests and Checkstyle (`./gradlew check`).  
+* Remember: Cursor is a **helper**, you remain the developer.  
+
+<box type="info" seamless>
+Treat Cursor like a coding buddy inside VS Code — fast, helpful, but always double-check its work.
+</box>
+
+---
+
+**Contributors**: Arshin Sikka ([@arshinsikka](https://github.com/arshinsikka))  


### PR DESCRIPTION
### Summary
Added three new tutorials under AI-Assisted Coding for using Cursor.

### Details
- **cursorSignup.md**: Step-by-step guide to creating a Cursor account and logging in.  
- **cursorIntellij.md**: Guide to using Cursor with IntelliJ IDEA via chat and refactor/explain workflows.  
- **cursorVscode.md**: Detailed walkthrough for Cursor in VS Code, including inline completions, chat, inline chat, refactoring, and responsible usage.

### Motivation
This fills a gap in AI-assisted coding tutorials by covering Cursor, which is becoming increasingly popular among students.  
It complements the existing Copilot and Windsurf tutorials, while highlighting Cursor as a practical "ChatGPT inside your IDE."

### Notes
- Student plan details (1-year free Pro in some regions) are included in the signup guide.  
- Screenshots can be added later to enhance the tutorials.

Closes #170 